### PR TITLE
Fix moving to next input with tab key

### DIFF
--- a/typeahead-focus.js
+++ b/typeahead-focus.js
@@ -17,6 +17,9 @@ angular.module('typeahead-focus', [])
 
           // Array of keyCode values for arrow keys
           const ARROW_KEYS = [37,38,39,40];
+          
+          // keyCodes for tab, enter & esc
+          const HOT_KEYS = [9, 13, 27];
 
           function manipulateViewValue(e) {
             /* we have to check to see if the arrow keys were in the input because if they were trying to select
@@ -25,6 +28,12 @@ angular.module('typeahead-focus', [])
              */
             if( ARROW_KEYS.indexOf(e.keyCode) >= 0 )
               return;
+            
+            // stop executing when we already have a value and "hot key" pressed
+            // to allow normal behaviour like moving to next input field
+            if (ngModel.$viewValue && HOT_KEYS.indexOf(e.keyCode) >= 0) {
+              return;
+            }
 
             var viewValue = ngModel.$viewValue;
 


### PR DESCRIPTION
Do not trigger the popup when "hot key" pressed if model has value

Preserve normal behavior for tab, enter and esc keys by not triggering the popup if there is already a value selected.